### PR TITLE
SEO Phase 1 — correctifs critiques (audit 2026-07-12)

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Consultant SEO et développeur web indépendant basé à Ajaccio (Corse), avec une antenne à Limoges. Création de sites vitrines sur-mesure rapides et SEO-ready, accompagnement en référencement naturel local, et offre spécialisée pour les cabinets d'expertise comptable partout en France. Ancien auditeur financier, tarifs affichés publiquement.
 
-Profil : freelance en direct (pas d'intermédiaire commercial), sites livrés en 4 à 6 semaines, clients autonomes sur leurs contenus après formation. Note Google : 5/5 (16 avis). Référencé France Num.
+Profil : freelance en direct (pas d'intermédiaire commercial), sites livrés en 4 à 6 semaines, clients autonomes sur leurs contenus après formation. Note Google : 5/5 (20 avis). Référencé France Num.
 
 ## Tarifs (HT, juin 2026)
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,7 +5,7 @@ import { getHomePermalink } from '~/utils/permalinks';
 const title = `Error 404`;
 ---
 
-<Layout metadata={{ title }}>
+<Layout metadata={{ title, robots: { index: false, follow: true } }}>
   <section class="flex items-center h-full p-16">
     <div class="container flex flex-col items-center justify-center px-5 mx-auto my-8">
       <div class="max-w-md text-center">

--- a/src/pages/[blog]/index.astro
+++ b/src/pages/[blog]/index.astro
@@ -44,7 +44,7 @@ const metadata = merge(
       "description": post.excerpt,
       "datePublished": post.publishDate?.toISOString(),
       "dateModified": (post.updateDate || post.publishDate)?.toISOString(),
-      ...(image ? { "image": image.src } : {}),
+      ...(image ? { "image": new URL(image.src, 'https://www.davidbarbier.com').href } : {}),
       "author": {
         "@type": "Person",
         "name": post.author,

--- a/src/pages/agence-seo-ajaccio.astro
+++ b/src/pages/agence-seo-ajaccio.astro
@@ -4,7 +4,7 @@ import Image from '../components/common/Image.astro';
 import HeroImage from '../assets/images/DSCF7551-3.jpg';
 import Activateur from "../assets/images/activateur.png"
 import { localBusinessAjaccioNode, LOCAL_BUSINESS_AJACCIO_ID } from '~/utils/business-schema';
-import { aggregateRatingSchemaAjaccio } from '~/utils/reviews';
+import { aggregateRatingSchemaAjaccio, GBP_AJACCIO_REVIEWS } from '~/utils/reviews';
 
 const metadata = {
   title: 'Référencement naturel SEO à Ajaccio : accompagnement mensuel | David Barbier',
@@ -206,7 +206,7 @@ const breadcrumbStructuredData = {
 
         <!-- Trust line -->
         <p class="mt-6 text-sm text-gray-500 dark:text-gray-400">
-          ⭐ 5/5 sur Google · 16 avis · +50 clients accompagnés · Basé à Ajaccio
+          ⭐ 5/5 sur Google · {GBP_AJACCIO_REVIEWS} avis · +50 clients accompagnés · Basé à Ajaccio
         </p>
 
         <!-- Problem statement -->

--- a/src/pages/audit-seo-ajaccio.astro
+++ b/src/pages/audit-seo-ajaccio.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../layouts/PageLayout.astro';
 import { localBusinessAjaccioNode, LOCAL_BUSINESS_AJACCIO_ID } from '~/utils/business-schema';
-import { aggregateRatingSchemaAjaccio } from '~/utils/reviews';
+import { aggregateRatingSchemaAjaccio, GBP_AJACCIO_REVIEWS } from '~/utils/reviews';
 
 const metadata = {
   title: 'Audit SEO complet à Ajaccio | David Barbier',
@@ -145,7 +145,7 @@ const breadcrumbStructuredData = {
       </p>
 
       <p class="mt-6 text-sm text-gray-500 dark:text-gray-400">
-        ⭐ 5/5 sur Google · 16 avis · +50 clients accompagnés · Basé à Ajaccio
+        ⭐ 5/5 sur Google · {GBP_AJACCIO_REVIEWS} avis · +50 clients accompagnés · Basé à Ajaccio
       </p>
 
       <p class="mt-6 text-lg text-gray-600 dark:text-gray-300 leading-relaxed">

--- a/src/pages/audit-seo-gratuit-ajaccio.astro
+++ b/src/pages/audit-seo-gratuit-ajaccio.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../layouts/PageLayout.astro';
 import { localBusinessAjaccioNode, LOCAL_BUSINESS_AJACCIO_ID } from '~/utils/business-schema';
-import { aggregateRatingSchemaAjaccio } from '~/utils/reviews';
+import { aggregateRatingSchemaAjaccio, GBP_AJACCIO_REVIEWS } from '~/utils/reviews';
 
 const metadata = {
   title: 'Audit SEO gratuit à Ajaccio | David Barbier',
@@ -133,7 +133,7 @@ const breadcrumbStructuredData = {
       </p>
 
       <p class="mt-6 text-sm text-gray-500 dark:text-gray-400">
-        ⭐ 5/5 sur Google · 16 avis · +50 clients accompagnés · Basé à Ajaccio
+        ⭐ 5/5 sur Google · {GBP_AJACCIO_REVIEWS} avis · +50 clients accompagnés · Basé à Ajaccio
       </p>
 
       <p class="mt-6 text-lg text-gray-600 dark:text-gray-300 leading-relaxed">

--- a/src/pages/limoges/index.astro
+++ b/src/pages/limoges/index.astro
@@ -34,10 +34,26 @@ const localBusinessSchema = {
   "founder": { "@id": "https://www.davidbarbier.com/#person" },
   "telephone": "+33623565299",
   "email": "hello@davidbarbier.com",
-  // Modèle service-area (SAB) : pas d'adresse physique tenue à Limoges —
-  // l'activité est domiciliée à Ajaccio (cf. mentions légales), on déclare
-  // uniquement la zone desservie. Une adresse fictive risquerait une
-  // suspension de fiche Google Business Profile.
+  // Adresse réelle (appartement) — cohérente avec la fiche Google Business
+  // Profile Limoges. Garder identique à la fiche (NAP consistency).
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "23 Rue de la Fonderie",
+    "addressLocality": "Limoges",
+    "postalCode": "87000",
+    "addressCountry": "FR"
+  },
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": 45.8352862,
+    "longitude": 1.2524095
+  },
+  "openingHoursSpecification": {
+    "@type": "OpeningHoursSpecification",
+    "dayOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+    "opens": "09:00",
+    "closes": "18:00"
+  },
   "areaServed": {
     "@type": "GeoCircle",
     "geoMidpoint": {
@@ -196,7 +212,7 @@ const testimonials = [
         <address class="mt-8 not-italic bg-green-50 dark:bg-green-950/30 rounded-lg p-6">
           <p class="text-lg font-semibold text-green-900 dark:text-green-100 mb-2">
             <Icon name="tabler:map-pin" class="inline mr-2 w-5 h-5" />
-            Limoges et Haute-Vienne — sur rendez-vous, sur place ou en visio
+            23 Rue de la Fonderie, 87000 Limoges
           </p>
           <p class="text-lg text-green-800 dark:text-green-200">
             <Icon name="tabler:phone" class="inline mr-2 w-5 h-5" />
@@ -609,7 +625,7 @@ const testimonials = [
           <div class="text-center sm:text-left">
             <h2 class="text-xl font-semibold text-white">
               <Icon name="tabler:map-pin" class="inline mr-2 w-5 h-5" />
-              Limoges et Haute-Vienne
+              23 Rue de la Fonderie, 87000 Limoges
             </h2>
             <p class="text-gray-400 mt-1">
               <Icon name="tabler:calendar" class="inline mr-1 w-4 h-4" />

--- a/src/pages/limoges/index.astro
+++ b/src/pages/limoges/index.astro
@@ -34,24 +34,10 @@ const localBusinessSchema = {
   "founder": { "@id": "https://www.davidbarbier.com/#person" },
   "telephone": "+33623565299",
   "email": "hello@davidbarbier.com",
-  "address": {
-    "@type": "PostalAddress",
-    "streetAddress": "23 Rue de la Fonderie",
-    "addressLocality": "Limoges",
-    "postalCode": "87000",
-    "addressCountry": "FR"
-  },
-  "geo": {
-    "@type": "GeoCoordinates",
-    "latitude": 45.8352862,
-    "longitude": 1.2524095
-  },
-  "openingHoursSpecification": {
-    "@type": "OpeningHoursSpecification",
-    "dayOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
-    "opens": "09:00",
-    "closes": "18:00"
-  },
+  // Modèle service-area (SAB) : pas d'adresse physique tenue à Limoges —
+  // l'activité est domiciliée à Ajaccio (cf. mentions légales), on déclare
+  // uniquement la zone desservie. Une adresse fictive risquerait une
+  // suspension de fiche Google Business Profile.
   "areaServed": {
     "@type": "GeoCircle",
     "geoMidpoint": {
@@ -203,14 +189,14 @@ const testimonials = [
 
         <!-- Trust line -->
         <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">
-          ⭐ 5/5 sur Google · +50 clients accompagnés · 20 ans à Limoges
+          ⭐ 5/5 sur Google · +50 clients accompagnés · Originaire de Limoges
         </p>
 
         <!-- NAP visible -->
         <address class="mt-8 not-italic bg-green-50 dark:bg-green-950/30 rounded-lg p-6">
           <p class="text-lg font-semibold text-green-900 dark:text-green-100 mb-2">
             <Icon name="tabler:map-pin" class="inline mr-2 w-5 h-5" />
-            23 Rue de la Fonderie, 87000 Limoges
+            Limoges et Haute-Vienne — sur rendez-vous, sur place ou en visio
           </p>
           <p class="text-lg text-green-800 dark:text-green-200">
             <Icon name="tabler:phone" class="inline mr-2 w-5 h-5" />
@@ -623,7 +609,7 @@ const testimonials = [
           <div class="text-center sm:text-left">
             <h2 class="text-xl font-semibold text-white">
               <Icon name="tabler:map-pin" class="inline mr-2 w-5 h-5" />
-              23 Rue de la Fonderie, 87000 Limoges
+              Limoges et Haute-Vienne
             </h2>
             <p class="text-gray-400 mt-1">
               <Icon name="tabler:calendar" class="inline mr-1 w-4 h-4" />

--- a/src/pages/optimisation-fiche-google-ajaccio.astro
+++ b/src/pages/optimisation-fiche-google-ajaccio.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../layouts/PageLayout.astro';
 import { localBusinessAjaccioNode, LOCAL_BUSINESS_AJACCIO_ID } from '~/utils/business-schema';
-import { aggregateRatingSchemaAjaccio } from '~/utils/reviews';
+import { aggregateRatingSchemaAjaccio, GBP_AJACCIO_REVIEWS } from '~/utils/reviews';
 
 const metadata = {
   title: "Optimisation fiche Google à Ajaccio | David Barbier",
@@ -153,7 +153,7 @@ const breadcrumbStructuredData = {
       </p>
 
       <p class="mt-6 text-sm text-gray-500 dark:text-gray-400">
-        ⭐ 5/5 sur Google · 16 avis · +50 clients accompagnés · Basé à Ajaccio
+        ⭐ 5/5 sur Google · {GBP_AJACCIO_REVIEWS} avis · +50 clients accompagnés · Basé à Ajaccio
       </p>
 
       <p class="mt-6 text-lg text-gray-600 dark:text-gray-300 leading-relaxed">

--- a/src/utils/business-schema.ts
+++ b/src/utils/business-schema.ts
@@ -61,9 +61,6 @@ export const localBusinessAjaccioNode = {
   priceRange: '€€',
 };
 
-// Modèle service-area (SAB) : pas d'adresse physique tenue à Limoges — l'activité
-// est domiciliée à Ajaccio (mentions légales). On déclare la zone desservie,
-// jamais d'adresse fictive (risque de suspension de fiche Google Business Profile).
 export const localBusinessLimogesNode = {
   '@type': 'LocalBusiness',
   '@id': LOCAL_BUSINESS_LIMOGES_ID,
@@ -74,10 +71,12 @@ export const localBusinessLimogesNode = {
   founder: { '@id': 'https://www.davidbarbier.com/#person' },
   telephone: '+33623565299',
   email: 'hello@davidbarbier.com',
-  areaServed: {
-    '@type': 'GeoCircle',
-    geoMidpoint: { '@type': 'GeoCoordinates', latitude: 45.8352862, longitude: 1.2524095 },
-    geoRadius: '50000',
+  address: {
+    '@type': 'PostalAddress',
+    streetAddress: '23 Rue de la Fonderie',
+    addressLocality: 'Limoges',
+    postalCode: '87000',
+    addressCountry: 'FR',
   },
   priceRange: '€€',
 };

--- a/src/utils/business-schema.ts
+++ b/src/utils/business-schema.ts
@@ -61,6 +61,9 @@ export const localBusinessAjaccioNode = {
   priceRange: '€€',
 };
 
+// Modèle service-area (SAB) : pas d'adresse physique tenue à Limoges — l'activité
+// est domiciliée à Ajaccio (mentions légales). On déclare la zone desservie,
+// jamais d'adresse fictive (risque de suspension de fiche Google Business Profile).
 export const localBusinessLimogesNode = {
   '@type': 'LocalBusiness',
   '@id': LOCAL_BUSINESS_LIMOGES_ID,
@@ -71,12 +74,10 @@ export const localBusinessLimogesNode = {
   founder: { '@id': 'https://www.davidbarbier.com/#person' },
   telephone: '+33623565299',
   email: 'hello@davidbarbier.com',
-  address: {
-    '@type': 'PostalAddress',
-    streetAddress: '23 Rue de la Fonderie',
-    addressLocality: 'Limoges',
-    postalCode: '87000',
-    addressCountry: 'FR',
+  areaServed: {
+    '@type': 'GeoCircle',
+    geoMidpoint: { '@type': 'GeoCoordinates', latitude: 45.8352862, longitude: 1.2524095 },
+    geoRadius: '50000',
   },
   priceRange: '€€',
 };

--- a/src/utils/reviews.ts
+++ b/src/utils/reviews.ts
@@ -4,7 +4,8 @@
  *
  * ⚠️ MAINTENANCE : quand tu reçois un nouvel avis Google, mets à jour :
  *   1. `REVIEWS` si tu veux afficher le témoignage sur le site
- *   2. `AGGREGATE_RATING.reviewCount` avec le total Google Business
+ *   2. `GBP_AJACCIO_REVIEWS` / `GBP_LIMOGES_REVIEWS` avec les totaux Google Business
+ *   3. `public/llms.txt` (le nombre d'avis y est en dur)
  */
 
 export interface Review {

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "redirects": [
     { "source": "/call", "destination": "/contact/", "permanent": true },
     { "source": "/call/", "destination": "/contact/", "permanent": true },
-        { "source": "/book-a-call", "destination": "/contact/", "permanent": true },
+    { "source": "/book-a-call", "destination": "/contact/", "permanent": true },
     { "source": "/book-a-call/", "destination": "/contact/", "permanent": true }
   ],
   "headers": [
@@ -14,6 +14,23 @@
         {
           "key": "Cache-Control",
           "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
         }
       ]
     }


### PR DESCRIPTION
## Contexte

Phase 1 du [plan d'action](https://github.com/davidbarbi3r/tikiton-agency/blob/master/clients/davidbarbier/audits/2026-07-12-full/ACTION-PLAN.md) issu de l'audit SEO complet du site pilote (score 76/100).

## Correctifs

| # | Correctif | Sévérité audit |
|---|---|---|
| ~~1.1~~ | ~~Limoges : adresse physique retirée~~ **ANNULÉ** — le constat « adresse fictive » de l'audit était une déduction erronée (SIRET Ajaccio + FAQ « tout en visio »). David a un appartement réel à cette adresse et une fiche GBP Limoges. L'adresse est restaurée à l'identique (cohérence NAP avec la fiche). | — |
| 1.2 | Badge « 20 ans à Limoges » → « Originaire de Limoges » (à côté des stats business, ça se lisait comme 20 ans d'activité). Le récit du corps de page — « j'ai vécu 20 ans à Limoges » — est conservé. | Critique → cosmétique |
| 1.3 | Avis : source unique de vérité. Les 4 pages Ajaccio affichaient « 16 avis » en dur vs `reviewCount: 20` en JSON-LD. Elles lisent désormais `GBP_AJACCIO_REVIEWS` ; `llms.txt` aligné. | Élevée |
| 1.4 | Images `Article` en URL absolue (`new URL(image.src, site)`) — les URLs relatives `/_astro/...` compromettaient l'éligibilité Discover. | Élevée |
| 1.5 | 404 en `noindex,follow` + en-têtes de sécurité (HSTS, X-Frame-Options, Permissions-Policy) dans `vercel.json`. | Élevée/Moyenne |

## Vérifications (build local, HTML généré)

- ✅ Adresse « 23 Rue de la Fonderie » présente (schema + NAP visible), identique à la fiche GBP
- ✅ Badge « 20 avis » rendu sur les 4 pages Ajaccio ; `reviewCount: 20` ; llms.txt à 20
- ✅ `"image":"https://www.davidbarbier.com/_astro/..."` sur les articles
- ✅ `<meta name="robots" content="noindex,follow">` sur la 404
- ✅ Build complet 35 pages sans erreur

## Notes

- **Suggestion suite au point 1.1** : la FAQ Limoges dit « tout se passe en visio » — reformuler (ex. « RDV sur place ou en visio ») pour que le contenu du site ne contredise pas la présence physique déclarée sur la fiche GBP.
- **CSP volontairement absente** : à faire dans une passe dédiée (scripts inline, GSAP, Umami).
- ⚠️ **À vérifier par David** : le vrai total d'avis sur la fiche Google (16 ou 20 ?) — constante `GBP_AJACCIO_REVIEWS` dans `src/utils/reviews.ts` (+ llms.txt).
- Aucun conflit attendu avec la refonte en cours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)